### PR TITLE
Fix handling talking when closing UE

### DIFF
--- a/UE/Application/Ports/UserPort.cpp
+++ b/UE/Application/Ports/UserPort.cpp
@@ -167,6 +167,12 @@ void UserPort::handleRejectClicked()
 
 bool UserPort::closeGuard()
 {
+    if(currentView == CurrentView::IncomingCall) {
+        handler->handleSendCallDropped(getCurrentRecipent());
+    } else if(currentView == CurrentView::OutgoingCall) {
+        handler->handleSendCallDrop(getCurrentRecipent());
+    }
+
     handler->handleClose();
     return true;
 }

--- a/UE/Application/States/TalkingState.cpp
+++ b/UE/Application/States/TalkingState.cpp
@@ -60,4 +60,10 @@ void TalkingState::handleReceivedCallDropped(common::PhoneNumber recipient)
     context.user.showCallDropped(recipient);
 }
 
+void TalkingState::handleClose()
+{
+    context.bts.sendCallDropped(recipient);
+    context.timer.stopTimer();
+}
+
 }

--- a/UE/Application/States/TalkingState.hpp
+++ b/UE/Application/States/TalkingState.hpp
@@ -17,9 +17,9 @@ public:
     void handleReceivedCallTalk(common::PhoneNumber, std::string) override;
     void handleTimeout() override;
     void handlePeerNotConnected(common::PhoneNumber) override;
-
-private:    
-	common::PhoneNumber recipient;
+    void handleClose() override;
+private:
+    common::PhoneNumber recipient;
 };
 
 }

--- a/UE/Tests/Application/ApplicationTestSuite.cpp
+++ b/UE/Tests/Application/ApplicationTestSuite.cpp
@@ -274,6 +274,7 @@ TEST_F(ApplicationConnectedTestSuite, shallHandleClose)
 TEST_F(ApplicationTalkingTestSuite, shallHandleClose)
 {
     EXPECT_CALL(timerPortMock, stopTimer());
+    EXPECT_CALL(btsPortMock, sendCallDropped(_));
     objectUnderTest.handleClose();
 }
 

--- a/UE/Tests/Application/Ports/UserPortTestSuite.cpp
+++ b/UE/Tests/Application/Ports/UserPortTestSuite.cpp
@@ -456,6 +456,26 @@ TEST_F(UserPortTestSuite, shallEmitCloseEvent)
     EXPECT_EQ(shouldClose, true);
 }
 
+TEST_F(UserPortTestSuite, shallDropIncomingCallOnClose)
+{
+    objectUnderTest.setCurrentMode(CurrentView::IncomingCall, &callModeMock);
+
+    EXPECT_CALL(handlerMock, handleSendCallDropped(_));
+    EXPECT_CALL(handlerMock, handleClose());
+    bool shouldClose = closeGuard();
+    EXPECT_EQ(shouldClose, true);
+}
+
+TEST_F(UserPortTestSuite, shallDropOutgoingCallOnClose)
+{
+    objectUnderTest.setCurrentMode(CurrentView::OutgoingCall, &callModeMock);
+
+    EXPECT_CALL(handlerMock, handleSendCallDrop(_));
+    EXPECT_CALL(handlerMock, handleClose());
+    bool shouldClose = closeGuard();
+    EXPECT_EQ(shouldClose, true);
+}
+
 TEST_F(UserPortTestSuite, shallShowSendedCallTalk)
 {
     common::PhoneNumber recipent{123};


### PR DESCRIPTION
Send proper drop call messages when we have an outgoing call request,
incoming call request and when we are talking with another UE